### PR TITLE
Fix Emacs 30 byte-compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+-include .config.mk
+
+PKG = elisp-depend
+
+ELS   = $(PKG).el
+ELCS  = $(ELS:.el=.elc)
+
+DEPS  =
+
+EMACS      ?= emacs
+EMACS_ARGS ?=
+
+LOAD_PATH  ?= $(addprefix -L ../,$(DEPS))
+LOAD_PATH  += -L .
+
+all: lisp
+
+help:
+	$(info make all        -- Build lisp)
+	$(info make lisp       -- Build lisp)
+	$(info make redo       -- Build lisp from scratch)
+	$(info make clean      -- Remove built files)
+	@printf "\n"
+
+redo: clean lisp
+
+lisp: $(ELCS) autoloads check-declare
+
+autoloads: $(PKG)-autoloads.el
+
+%.elc: %.el
+	@printf "Compiling $<\n"
+	@$(EMACS) -Q --batch $(EMACS_ARGS) $(LOAD_PATH) -f batch-byte-compile $<
+
+check-declare:
+	@printf " Checking function declarations\n"
+	@$(EMACS) -Q --batch $(EMACS_ARGS) $(LOAD_PATH) \
+	--eval "(check-declare-directory default-directory)"
+
+CLEAN = $(ELCS) $(PKG)-autoloads.el
+
+clean:
+	@printf " Cleaning...\n"
+	@rm -rf $(CLEAN)
+
+$(PKG)-autoloads.el: $(ELS)
+	@printf " Creating $@\n"
+	@$(EMACS) -Q --batch -l autoload --eval "\
+(let* ((file (expand-file-name \"$@\"))\
+       (generated-autoload-file file)\
+       (coding-system-for-write 'utf-8-emacs-unix)\
+       (backup-inhibited t)\
+       (version-control 'never)\
+       (inhibit-message t))\
+  (write-region (autoload-rubric file \"package\" t) nil file)\
+  (update-directory-autoloads default-directory))" \
+	2>&1 | sed "/^Package autoload is deprecated$$/d"

--- a/elisp-depend.el
+++ b/elisp-depend.el
@@ -1,4 +1,4 @@
-;;; elisp-depend.el --- Parse depend libraries of elisp file.
+;;; elisp-depend.el --- Parse depend libraries of elisp file. -*-lexical-binding: t-*-
 
 ;; Copyright (C) 2009  Andy Stewart
 ;; Copyright (C) 2010-2012 Tom Breton
@@ -73,7 +73,7 @@
 
 ;;;; Customize:
 ;;
-;; `elisp-depend-directory-list' the install directory of emacs.
+;; `elisp-depend-directory-list' the install directory of Emacs.
 ;; Or you can add others directory that you want filter.
 ;;
 ;; All of the above can customize by:
@@ -127,6 +127,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'view)                         ; use: `view-exit-action'
 
 ;;; Options
 
@@ -138,15 +139,16 @@
 ;;;###autoload
 (defcustom elisp-depend-directory-list '("/usr/share/emacs/")
   "List of directories that search should ignore."
-  :type 'list
+  :type '(repeat string)
   :group 'elisp-depend)
 
 ;;; Commands
 
+
 ;;;###autoload
 (defun elisp-depend-print-dependencies (&optional built-in)
   "Print library dependencies of the current buffer.
-With prefix argument, don't include built-in libraries.
+With BUILT-IN prefix argument, don't include built-in libraries.
 Every library that has a parent directory in
 `elisp-depend-directory-list' is considered built-in."
   (interactive "P")
@@ -172,7 +174,7 @@ Every library that has a parent directory in
 
 ;;;###autoload
 (defun elisp-depend-insert-require ()
-  "Insert a block of (require sym) or 'autoload statements into an elisp file."
+  "Insert a block of (require sym) or autoload statements into an elisp file."
   (interactive)
   (let ((deps (elisp-depend-map))
         library-name)
@@ -203,7 +205,7 @@ Every library that has a parent directory in
 ;;; Functions
 
 (defun elisp-depend-read-tree (&optional buffer)
-  "Return the tree given by reading the buffer as elisp.
+  "Return the tree given by reading the BUFFER as elisp.
 The top level is presented as a list, as if the buffer contents had been
 \(list CONTENTS...\)"
   (let ((tree '()))
@@ -223,7 +225,7 @@ The top level is presented as a list, as if the buffer contents had been
 ;; Borrowed from format
 (defun elisp-depend-proper-list-p (list)
   "Return t if LIST is a proper list.
-A proper list is a list ending with a nil cdr, not with an atom "
+A proper list is a list ending with a nil cdr, not with an atom"
   (when (listp list)
     (while (consp list)
       (setq list (cdr list)))
@@ -283,8 +285,8 @@ are mentioned in them."
 
     (let elisp-depend-let-form->sym-list)
     (let* elisp-depend-let-form->sym-list))
-  "Alist of symbols to expand specially, mapping from symbol to
-explore function.  Explore functions take one argument, a sexp, and
+  "Alist of symbols to expand specially, mapping symbol to explore function.
+Explore functions take one argument, a sexp, and
 return a list of symbols.")
 
 (defun elisp-depend-sexp->sym-list (sexp)
@@ -313,7 +315,10 @@ This function does not expand macros."
 
 ;; Translate symbols to requirements
 
-(defun elisp-depend-sym-list->dependencies (sym-list current-filename built-in see-vars)
+(defun elisp-depend-sym-list->dependencies (sym-list
+                                            current-filename
+                                            built-in
+                                            see-vars)
   ""
   (let ((symbol-seen '())
         (dependencies '()))
@@ -366,8 +371,7 @@ Return depend map as format: (filepath symbol-A symbol-B symbol-C)."
      nil)))
 
 (defun elisp-depend-get-load-history-line (path-sans-ext extension)
-  "Return line in load-history correspoding to PATH-SANS-EXT with
-   EXTENSION.
+  "Return line in `load-history' corresponding to PATH-SANS-EXT with EXTENSION.
 Return nil if there is none."
   (assoc (concat path-sans-ext extension)
          load-history))

--- a/elisp-depend.el
+++ b/elisp-depend.el
@@ -1,4 +1,4 @@
-;;; elisp-depend.el --- Parse depend libraries of elisp file. -*-lexical-binding: t-*-
+;;; elisp-depend.el --- Parse depend libraries of elisp file  -*-lexical-binding: t-*-
 
 ;; Copyright (C) 2009  Andy Stewart
 ;; Copyright (C) 2010-2012 Tom Breton
@@ -206,7 +206,7 @@ Every library that has a parent directory in
 
 (defun elisp-depend-read-tree (&optional buffer)
   "Return the tree given by reading the BUFFER as elisp.
-The top level is presented as a list, as if the buffer contents had been
+The top level is presented as a list, as if the buffer contents had been.
 \(list CONTENTS...\)"
   (let ((tree '()))
     (with-current-buffer (or buffer (current-buffer))
@@ -225,7 +225,7 @@ The top level is presented as a list, as if the buffer contents had been
 ;; Borrowed from format
 (defun elisp-depend-proper-list-p (list)
   "Return t if LIST is a proper list.
-A proper list is a list ending with a nil cdr, not with an atom"
+A proper list is a list ending with a nil cdr, not with an atom."
   (when (listp list)
     (while (consp list)
       (setq list (cdr list)))
@@ -238,8 +238,7 @@ A proper list is a list ending with a nil cdr, not with an atom"
 ;; by arglists, let forms, etc.
 
 (defun elisp-depend-get-syms-recurse (sexp n)
-  "Gets syms from a form that ignores the first N arguments and
-recurses on the rest."
+  "Get syms from form that ignores first N arguments and recurses on the rest."
   (if (elisp-depend-proper-list-p sexp)
       (cl-mapcan #'elisp-depend-sexp->sym-list (nthcdr n sexp))
     ;; If it's a dotted list, complain.
@@ -319,7 +318,6 @@ This function does not expand macros."
                                             current-filename
                                             built-in
                                             see-vars)
-  ""
   (let ((symbol-seen '())
         (dependencies '()))
     ;; Poor-man's dolist


### PR DESCRIPTION
-Fix the warnings to prevent seeing them each time the package is installed.
  - Also use lexical-binding.  I did not see anything that made it depend from dynamic binding; setting lexical-binding explicitly generates a little faster code and prevent Emacs >= 30 from complaining.
- Fix the defcustom `:type list` into a `(repeat string).  No need to check the presence of the directory since their name is used for filtering.
- Wrap a long line. 

* Fix the following warnings:

  elisp-depend.el:1:1: Warning: file has no ‘lexical-binding’ directive on its
      first line
  elisp-depend.el:141:10: Warning: in defcustom for
      ‘elisp-depend-directory-list’: ‘list’ without arguments

  In elisp-depend-print-dependencies:
  elisp-depend.el:166:11: Warning: assignment to free variable
      ‘view-exit-action’

  In elisp-depend-insert-require:
  elisp-depend.el:174:2: Warning: docstring has wrong usage of unescaped single
      quotes (use \=' or different quoting such as `...')

* Also fix some of the checkdoc reported warnings but not all.
